### PR TITLE
Fix crash on startup

### DIFF
--- a/common/src/main/java/gg/moonflower/carpenter/core/Carpenter.java
+++ b/common/src/main/java/gg/moonflower/carpenter/core/Carpenter.java
@@ -46,6 +46,7 @@ public class Carpenter {
         CarpenterBlocks.CHEST_REGISTRY.register();
         CarpenterBlocks.BLOCK_ENTITY_REGISTRY.register(Carpenter.PLATFORM);
         CarpenterRecipes.REGISTRY.register(Carpenter.PLATFORM);
+        CarpenterChests.REGISTRY.register(Carpenter.PLATFORM);
     }
 
     public static void onCommonPostInit(Platform.ModSetupContext ctx) {

--- a/common/src/main/java/gg/moonflower/carpenter/impl/registry/ChestRegistryImpl.java
+++ b/common/src/main/java/gg/moonflower/carpenter/impl/registry/ChestRegistryImpl.java
@@ -56,7 +56,6 @@ public class ChestRegistryImpl implements ChestRegistry {
     public void register() {
         this.itemRegistry.register(this.platform);
         this.blockRegistry.register(this.platform);
-        this.chestTypeRegistry.register(this.platform);
     }
 
     @Override


### PR DESCRIPTION
This fixes a crash caused by the new `ChestRegistry`. When only Carpenter was present, the system worked normally.  However, `register()` registers Carpenter's chest type registry each time it's called, which could lead to a crash caused by it being registered more than once when another mod adds their own chest registry.

This fixes the issue by registering Carpenter's chest registry in the common init instead of each time a chest registry is registered.